### PR TITLE
Typo in "Getting Started"

### DIFF
--- a/watir-login.rb
+++ b/watir-login.rb
@@ -65,13 +65,15 @@ class AlexaCrawler
 end
 
 
-def start_crawler	
+def start_crawler(last_command = nil)
 	begin
 		a = AlexaCrawler.new	
+                a.last_command = last_command
 		a.keep_alive
 	rescue
+		last_command = a.last_command
 		a.kill
-		start_crawler
+		start_crawler(last_command)
 	end
 end
 


### PR DESCRIPTION
4) Type chmod +x startScript.sh && ./startupScript.sh

Should be:

Type chmod +x startupScript.sh && ./startupScript.sh
