### PR TITLE
Act on groups of lights

### DIFF
--- a/server/modules/hue/module.rb
+++ b/server/modules/hue/module.rb
@@ -5,9 +5,11 @@ class AlexaHue
 
   HUE_CLIENT = Hue::Client.new
 
-  ZACH_ROOM_LIGHTS = ["bedside", "overhead"]
-
   SATURATION_MODIFIERS = {lighter: 200, light: 200, darker: 255, dark: 255, darkest: 200}
+
+  GROUPS = {}
+
+  HUE_CLIENT.groups.each do |g| GROUPS[g.name] = g.id end 
 
   def wake_words
     ["light", "lights"]
@@ -19,8 +21,12 @@ class AlexaHue
     # Select lights
     if command.scan(/all/).length > 0
       lights_to_act_on = HUE_CLIENT.lights
-    elsif command.scan(/room/).length > 0
-      lights_to_act_on = HUE_CLIENT.lights.select{|light| ZACH_ROOM_LIGHTS.include?(light.name.downcase)}
+    elsif  GROUPS.keys.any? { |g| command.include?(g.downcase) }
+      GROUPS.keys.each do |k|
+        if command.include?(k.downcase)
+        lights_to_act_on = HUE_CLIENT.group(GROUPS[k])
+        end
+      end
     else
       lights_to_act_on = HUE_CLIENT.lights.select{|light| command.split(" ").include?(light.name.downcase)}
     end

--- a/server/modules/hue/module.rb
+++ b/server/modules/hue/module.rb
@@ -90,13 +90,17 @@ class AlexaHue
 
   def light_command(lights, options = {})
     p options
-    lights.each do |light|
-      light.on = options[:on] if !options[:on].nil?
-      light.set_state(options[:color]) if !options[:color].nil?
+      if lights.class = Hue::Group
+        lights.on = options[:on] if !options[:on].nil?
+        lights.set_state(options[:color]) if !options[:color].nil?
+        sleep(0.5)
+      else lights.each do |light|
+        light.on = options[:on] if !options[:on].nil?
+        light.set_state(options[:color]) if !options[:color].nil?
       sleep(0.5)
+      end
     end
   end
-
 end
 
 MODULE_INSTANCES.push(AlexaHue.new)

--- a/server/modules/hue/module.rb
+++ b/server/modules/hue/module.rb
@@ -90,14 +90,14 @@ class AlexaHue
 
   def light_command(lights, options = {})
     p options
-      if lights.class = Hue::Group
+      if lights.class == Hue::Group
         lights.on = options[:on] if !options[:on].nil?
         lights.set_state(options[:color]) if !options[:color].nil?
         sleep(0.5)
       else lights.each do |light|
         light.on = options[:on] if !options[:on].nil?
         light.set_state(options[:color]) if !options[:color].nil?
-      sleep(0.5)
+        sleep(0.5)
       end
     end
   end


### PR DESCRIPTION
Minor revision to improve the light module to automatically detect, and act on, light groups instead
of having to hardcode the groups in. All existing commands (color, brightness, etc) will now work on groups.
