### PR TITLE
Scene support

### DIFF
--- a/server/modules/hue/module.rb
+++ b/server/modules/hue/module.rb
@@ -1,4 +1,5 @@
 require 'hue'
+require_relative './scenes/scenes'
 
 
 class AlexaHue
@@ -35,6 +36,12 @@ class AlexaHue
       GROUPS.keys.each do |k|
         if command.include?(k.downcase)
         lights_to_act_on = HUE_CLIENT.group(GROUPS[k])
+        end
+      end
+    elsif SCENES.keys.any? { |n| command.include?(n.downcase.gsub('-',' ')) }
+      SCENES.keys.each do |k|
+        if command.include?(k.downcase.gsub('-', ' '))
+          HUE_CLIENT.group(SCENES[k]).set_state({scene: k})
         end
       end
     else

--- a/server/modules/hue/scenes/Scene Support.md
+++ b/server/modules/hue/scenes/Scene Support.md
@@ -1,0 +1,22 @@
+Scene Support
+
+A small upgrade to support calling up Hue scenes with Alexa.
+
+Background:
+Scenes are stored/recalled on the bridge by scene ids. Since many Hue apps assign a random alphanumeric string for a scene id, it isn't practical to try to get Alexa to call up all existing scenes directly. A scene with the id "Dinner" can be called up; one with the id 0-AF45THX-11 cannot. Since currently the Hue API doesn't support renaming (or deletion) of scenes, it likely that most of your current scenes can't be accessed through an Alexa voice command.
+
+Usage:
+This add-on has two files 
+- 'scene_names.yml' contains the names of the (voice-regognizable) scenes you want Alexa to recognize. 
+- 'capture_scenes.rb' allows you to capture your current light configuration, and give it a name that Alexa *can* recognize.
+
+Simply set your lights how you'd like, and run "ruby capture_scenes.rb" in the terminal. Name your scene and assign it to a group (names of existing groups will be listed). After you reset Alexa Home the scenes can be recalled, e.g., "Alexa, romantic lights"
+
+(You can also add existing scene to the yaml file manually. You'll need to know the number of the group the scene is assigned to. That can be found with the Hue Debug Tool: http://<bridge ip address>/debug/clip.html)
+
+
+
+
+
+
+

--- a/server/modules/hue/scenes/scene_capture.rb
+++ b/server/modules/hue/scenes/scene_capture.rb
@@ -1,0 +1,44 @@
+require 'hue'
+require 'yaml'
+require 'httparty'
+
+LIGHTS_IN_GROUP = []
+GROUPS = {}
+
+@client ||= Hue::Client.new
+@client.groups.each do |g| GROUPS[g.name] = g.id end 
+
+def prompt(*args)
+ print(*args)
+ gets.chomp
+end
+
+def scene_in_group
+	puts "\nHere are your groups:\n\n"
+	puts GROUPS.keys
+	group = prompt "\nEnter the group for this scene: "
+		if GROUPS.keys.include?(group)
+			@client.group((GROUPS[group]).to_i).lights.each { |l| LIGHTS_IN_GROUP.push(l.id) }
+			@scene_group = GROUPS[group]
+			puts "\nScene Created"
+		else
+			puts "\nThat group doesn't exist. Please choose from among your existing groups\n CTRL-C to exit\n"	
+			scene_in_group
+		end
+end
+
+scene_name = prompt "\nEnter the name of the scene: "
+scene_name.gsub!(' ','-')
+puts "\nThank you."
+
+scene_in_group
+
+params = {name: scene_name, lights:LIGHTS_IN_GROUP}
+
+#adding scene to bridge
+HTTParty.put("http://#{@client.bridge.ip}/api/#{@client.username}/scenes/#{scene_name}", :body => params.to_json)
+
+scene_info = {scene_name => @scene_group}
+
+File.open('scene_names.yml', 'a+') { |lines| lines.write(scene_info.to_yaml) }
+

--- a/server/modules/hue/scenes/scene_names.yml
+++ b/server/modules/hue/scenes/scene_names.yml
@@ -1,0 +1,2 @@
+---
+example-scene-name: '1' 

--- a/server/modules/hue/scenes/scenes.rb
+++ b/server/modules/hue/scenes/scenes.rb
@@ -1,0 +1,6 @@
+require 'yaml'
+	
+scene_file = File.dirname(File.expand_path(__FILE__)) + '/scene_names.yml'
+s = YAML.load_stream(open(scene_file))
+SCENES = s.reduce :update
+


### PR DESCRIPTION
I’m sure Amazon will roll this out soon, but until then….

Because existing hue scenes very likely aren’t voice recognizable (or
renameable), I’ve included a utility that allows you to easily create
(or replicate) scenes with names that are.
